### PR TITLE
Upgrade to PMA 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,34 @@
-FROM phpmyadmin/phpmyadmin
+FROM phpmyadmin/phpmyadmin:5
+
 MAINTAINER Elze Kool <e.kool@kooldevelopment.nl>
 
-
-# Install wget and install/updates certificates
-RUN apk add --no-cache --virtual .run-deps \
-    ca-certificates bash wget \
-    && update-ca-certificates
+# Install wget, go and git
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    wget golang git
     
 # Install Docker Gen
-ENV DOCKER_GEN_VERSION 0.7.3
+ENV DOCKER_GEN_VERSION 0.7.7
 
-RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz -O /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+ && tar -C /usr/local/bin -xvzf /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
 # Install Forego
-RUN wget --quiet https://github.com/jwilder/forego/releases/download/v0.16.1/forego -O /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+RUN go get -u github.com/nginx-proxy/forego \
+ && mv ~/go/bin/forego /usr/local/bin/forego
+
+RUN mv /docker-entrypoint.sh /docker-entrypoint-pma.sh
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+
 RUN chmod u+rwx /docker-entrypoint.sh
+
 COPY Procfile /Procfile
 COPY pma-config.tmpl /pma-config.tmpl
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
-CMD ["forego", "start", "-r"]
+
+CMD ["forego", "start", "-r", "-f", "/Procfile"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-phpmyadmin: /run.sh phpmyadmin
-dockergen: docker-gen -watch -notify "killall php-fpm7" /pma-config.tmpl /etc/phpmyadmin/config.inc.php
+phpmyadmin: /docker-entrypoint-pma.sh apache2-foreground
+dockergen: docker-gen -watch -notify "apache2ctl restart" /pma-config.tmpl /etc/phpmyadmin/config.inc.php


### PR DESCRIPTION
- Update forego
- Update Docker Gen
- Update base image to PMA 5 (apache)
- Fix issue where the template was not working after updating Docker to 20.10.9