### PR TITLE
Split build process to allow multi arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,27 @@
-FROM phpmyadmin/phpmyadmin:5
+# Download Docker Gen
+FROM --platform=$BUILDPLATFORM alpine as docker-gen
+ARG DOCKER_GEN_VERSION=0.7.7
+ARG TARGETARCH
+RUN echo "Downloading Docker Gen $DOCKER_GEN_VERSION for $TARGETARCH" \
+ && wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-$TARGETARCH-$DOCKER_GEN_VERSION.tar.gz -O /docker-gen.tar.gz
+
+# Download Forego
+FROM --platform=$TARGETPLATFORM golang as forego
+RUN go install github.com/nginx-proxy/forego@main
+
+FROM phpmyadmin:5
 
 MAINTAINER Elze Kool <e.kool@kooldevelopment.nl>
 
-# Install wget, go and git
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    wget golang git
-    
-# Install Docker Gen
-ENV DOCKER_GEN_VERSION 0.7.7
-
-RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz -O /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
-
 # Install Forego
-RUN go get -u github.com/nginx-proxy/forego \
- && mv ~/go/bin/forego /usr/local/bin/forego
+COPY --from=forego /go/bin/forego /usr/local/bin/forego
+
+# Install Docker Gen
+COPY --from=docker-gen /docker-gen.tar.gz /docker-gen.tar.gz
+RUN tar -C /usr/local/bin -xvzf /docker-gen.tar.gz \
+ && rm /docker-gen.tar.gz
 
 RUN mv /docker-entrypoint.sh /docker-entrypoint-pma.sh
-
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN chmod u+rwx /docker-entrypoint.sh


### PR DESCRIPTION
Note: I've already pushed the image to https://hub.docker.com/r/elzekool/pma-autoconfig as `elzekool/pma-autoconfig:latest`

I've used Docker buildx on my mac to create a multiarch image:

1. `docker buildx create --driver docker-container --name local --use unix:///var/run/docker.sock`
2. `docker buildx inspect --bootstrap local` and verify that it shows at least `linux/amd64` and `linux/arm64` as available platforms
3. `docker buildx build --platform linux/arm64,linux/amd64 -t elzekool/pma-autoconfig:latest .` to build and check if the build is working. add `--push` to push the image to docker hub